### PR TITLE
Support for gcc cross compilers

### DIFF
--- a/colorgcc.pl
+++ b/colorgcc.pl
@@ -107,7 +107,15 @@ sub initDefaults
   $compilerPaths{"g++"} = "/usr/bin/g++";
   $compilerPaths{"cc"}  = "/usr/bin/cc";
   $compilerPaths{"c++"} = "/usr/bin/c++";
-
+  
+  
+  #Actual paths to these cross compilers will need to be
+  #set in colorgccrc
+  $compilerPaths{"mips-linux-gcc"} = "/usr/bin/mips-linux-gcc";
+  $compilerPaths{"mipsel-linux-gcc"} = "/usr/bin/mipsel-linux-gcc";
+  $compilerPaths{"arm-linux-gcc"} = "/usr/bin/arm-linux-gcc";
+  $compilerPaths{"armeb-linux-gcc"} = "/usr/bin/armeb-linux-gcc";
+   
   $nocolor{"dumb"} = "true";
 
   $colors{"srcColor"} = color("cyan");

--- a/colorgccrc.txt
+++ b/colorgccrc.txt
@@ -27,6 +27,13 @@ gcc: /usr/bin/gcc
 c++: /usr/bin/c++
 cc:  /usr/bin/cc
 
+# Cross compilers
+arm-linux-gcc: /opt/gcc/arm/host/usr/bin/arm-linux-gcc
+armeb-linux-gcc: /opt/gcc/armeb/host/usr/bin/armeb-linux-gcc
+mips-linux-gcc: /opt/gcc/mips/host/usr/bin/mips-linux-gcc
+mipsel-linux-gcc: /opt/gcc/mipsel/host/usr/bin/mipsel-linux-gcc
+
+
 # Define aliases for the usual compilers to allow using colorgcc
 # without path munging.  (E.g. make CXX=color-g++)
 color-g++: /usr/bin/g++


### PR DESCRIPTION
I updated colorgcc.pl and colorgccrc.txt to support arm, armeb, mips and mipsel gcc cross compilers.  Should be easy to add support for other architectures as well, or for g++ cross compilers.
